### PR TITLE
adding sensor type for PT1000 on extruder

### DIFF
--- a/Firmware/300_printer.cfg
+++ b/Firmware/300_printer.cfg
@@ -186,11 +186,11 @@ min_temp: 0
 max_temp: 280
 min_extrude_temp: 0
 
-# PT100
+# NTC100K B3950
 sensor_type: Generic 3950
 sensor_pin: EBBCan: PA3
 
-# PT1000
+# PT100 / PT1000
 # sensor_type: MAX31865
 # sensor_pin: EBBCan: PA4
 # spi_bus: spi1

--- a/Firmware/300_printer.cfg
+++ b/Firmware/300_printer.cfg
@@ -177,8 +177,6 @@ gear_ratio: 50:10
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: EBBCan: PB13
-sensor_type: Generic 3950
-sensor_pin: EBBCan: PA3
 pressure_advance: 0.036
 control: pid
 pid_Kp: 21.527
@@ -188,6 +186,17 @@ min_temp: 0
 max_temp: 280
 min_extrude_temp: 0
 
+# PT100
+sensor_type: Generic 3950
+sensor_pin: EBBCan: PA3
+
+# PT1000
+# sensor_type: MAX31865
+# sensor_pin: EBBCan: PA4
+# spi_bus: spi1
+# rtd_nominal_r: 100
+# rtd_reference_r: 430
+# rtd_num_of_wires: 2
 
 
 [tmc2209 extruder]

--- a/Firmware/350_printer.cfg
+++ b/Firmware/350_printer.cfg
@@ -186,11 +186,11 @@ min_temp: 0
 max_temp: 280
 min_extrude_temp: 0
 
-# PT100
+# NTC100K B3950
 sensor_type: Generic 3950
 sensor_pin: EBBCan: PA3
 
-# PT1000
+# PT100 / PT1000
 # sensor_type: MAX31865
 # sensor_pin: EBBCan: PA4
 # spi_bus: spi1

--- a/Firmware/350_printer.cfg
+++ b/Firmware/350_printer.cfg
@@ -177,8 +177,6 @@ gear_ratio: 50:10
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: EBBCan: PB13
-sensor_type: Generic 3950
-sensor_pin: EBBCan: PA3
 pressure_advance: 0.036
 control: pid
 pid_Kp: 21.527
@@ -188,6 +186,17 @@ min_temp: 0
 max_temp: 280
 min_extrude_temp: 0
 
+# PT100
+sensor_type: Generic 3950
+sensor_pin: EBBCan: PA3
+
+# PT1000
+# sensor_type: MAX31865
+# sensor_pin: EBBCan: PA4
+# spi_bus: spi1
+# rtd_nominal_r: 100
+# rtd_reference_r: 430
+# rtd_num_of_wires: 2
 
 
 [tmc2209 extruder]


### PR DESCRIPTION
when using PT1000, such as from the Rapido UHF, these settings are required. would be good to have them documented as examples.