### PR TITLE
Update 350_printer_m8p_v2.cfg

### DIFF
--- a/Firmware/350_printer_m8p_v2.cfg
+++ b/Firmware/350_printer_m8p_v2.cfg
@@ -214,7 +214,7 @@ heater_temp: 50.0
 
 
 [heater_bed]
-heater_pin: PF5
+heater_pin:  PA1
 sensor_type: Generic 3950
 sensor_pin: PB1
 max_power: 1.0


### PR DESCRIPTION
REV 1.1
Changed incorrect Bed Heater  pin from PF5 to PA1

[heater_bed]
heater_pin:  PA1